### PR TITLE
Add support for generating client libraries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,14 +25,32 @@ If you have installed polycube in the standard location and everything is ok you
 
 ::
 
-    $ polycube-codegen [-h] [-i input_yang] [-o output_folder] [-s output_swagger_file]
+    $ polycube-codegen [-h] [-i input_yang] [-o output_folder] [-s output_swagger_file] [-l client_language]
     Polycube code generator that translates a YANG file into an polycube C++ service stub
 
     where:
         -h  show this help text
         -i  path to the input YANG file
         -o  path to the destination folder where the service stub will be placed
-        -s  path to the destination swagger file (optional)"
+        -s  path to the destination swagger file (optional)
+        -l  language used to generate service's client library (optional)"
+
+Client stub for Polycube services
+^^^^^^
+
+Each Polycube service uses a specific convention for generate the REST APIs that are used by external players to interact with the service itself. 
+In order to interact with those service, users can use the ``polycubectl`` CLI tool or creates their own client programs that communicates with a given service.
+To simplify the creation of those programs, ``polycube-codegen`` supports the generation of client stubs in different programming languages such as ``golang``, ``java``, ``python`` (full list available `here <https://github.com/swagger-api/swagger-codegen#overview>`_ under the ``swagger-codegen`` project).
+
+To do this, we can directly use the provided ``polycube-codegen`` script adding the ``-l`` option with the name of the language you want to use.
+For instance, in order to generate the client stub for the ``pcn-simplebridge`` service, the command that you can use is the following:
+
+::
+
+    polycube-codegen -i pcn-simplebridge.yang -o output_dir -l go
+
+Alternatively, if you do not want to install the ``polycube-codegen`` tool, you can use the same syntax in the provided Docker image.
+
 
 Docker
 ^^^^^^

--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,9 @@ For instance, in order to generate the client stub for the ``pcn-simplebridge`` 
 
     polycube-codegen -i pcn-simplebridge.yang -o output_dir -l go
 
-Alternatively, if you do not want to install the ``polycube-codegen`` tool, you can use the same syntax in the provided Docker image.
+In its final processing step, polycube-codegen relies on the online service https://generator.swagger.io/api/gen/clients generator to create the code stub; hence this requires Internet connectivity.
 
+Alternatively, if you do not want to install the ``polycube-codegen`` tool, you can use the same syntax in the provided Docker image.
 
 Docker
 ^^^^^^

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ PACKAGES=""
 PACKAGES+=" sudo git wget"
 PACKAGES+=" python-minimal python-pip python-setuptools" # dependencies for pyang swagger
 PACKAGES+=" default-jre default-jdk maven" # dependencies for swaggercodegen
+PACKAGES+=" jq" # dependencies for json parsing on bash scripts
 
 $SUDO $APT_CMD install -y $PACKAGES
 

--- a/polycube-codegen.sh
+++ b/polycube-codegen.sh
@@ -7,6 +7,7 @@ set -e
 SWAGGER_CONFIG_FILE=$HOME/.config/polycube/swagger_codegen_config.json
 POLYCUBE_CODEGEN_LOG=/dev/null
 SWAGGER_CODEGEN_CLI=/usr/local/bin/swagger-codegen-cli.jar
+CLIENT_LANG=polycube
 
 function exit_error() {
 	if [ "$?" -ne "0" ]; then
@@ -17,21 +18,23 @@ function exit_error() {
 }
 
 function show_help() {
-usage="$(basename "$0") [-h] [-i input_yang] [-o output_folder] [-s output_swagger_file]
+usage="$(basename "$0") [-h] [-i input_yang] [-o output_folder] [-s output_swagger_file] [-l client_language]
 Polycube code generator that translates a YANG file into an polycube C++ service stub
 
 where:
     -h  show this help text
     -i  path to the input YANG file
     -o  path to the destination folder where the service stub will be placed
-    -s  path to the destination swagger file (optional)"
+    -s  path to the destination swagger file (optional)
+    -l  language used to generate service's client library (optional)"
 
 echo "$usage"
 }
 
+
 trap exit_error EXIT
 
-while getopts :i:o:s:h option; do
+while getopts :i:o:s:l:h option; do
  case "${option}" in
  h|\?)
 	show_help
@@ -43,6 +46,8 @@ while getopts :i:o:s:h option; do
 	;;
  s) OUT_SWAGGER_PATH=${OPTARG}
  	;;
+ l) CLIENT_LANG=${OPTARG}
+ 	;;	
  :)
     echo "Option -$OPTARG requires an argument." >&2
     show_help
@@ -93,10 +98,10 @@ if [ -n "${OUT_SWAGGER_PATH+set}" ]; then
 fi
 
 if [ -f $SWAGGER_CONFIG_FILE ]; then
-	java -jar $SWAGGER_CODEGEN_CLI generate -l polycube -i /tmp/"$json_filename" \
+	java -jar $SWAGGER_CODEGEN_CLI generate -l ${CLIENT_LANG} -i /tmp/"$json_filename" \
 		-o $OUT_FOLDER --config $SWAGGER_CONFIG_FILE > $POLYCUBE_CODEGEN_LOG 2>&1
 else
-	java -jar $SWAGGER_CODEGEN_CLI generate -l polycube -i /tmp/"$json_filename" \
+	java -jar $SWAGGER_CODEGEN_CLI generate -l ${CLIENT_LANG} -i /tmp/"$json_filename" \
 		-o $OUT_FOLDER > $POLYCUBE_CODEGEN_LOG 2>&1
 fi
 
@@ -104,7 +109,7 @@ rm /tmp/"$json_filename"
 
 cd $_pwd
 
-echo "C++ service stub generated under $OUT_FOLDER"
+echo "$CLIENT_LANG output generated under $OUT_FOLDER"
 exit 0
 
 


### PR DESCRIPTION
This PR adds support for generating client libraries within different languages supported by the swagger-codegen tool (full list available here [1]).
By default, polycube is used as the target for the stub generation. However, a new option on this script (`-l`) allows specifying a different target language to use.

[1] https://github.com/swagger-api/swagger-codegen#overview